### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/LandmarkRegistration/CompareVolumes.py
+++ b/LandmarkRegistration/CompareVolumes.py
@@ -99,7 +99,6 @@ class CompareVolumesWidget:
     #
     self.inputSelector = slicer.qMRMLNodeComboBox()
     self.inputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inputSelector.selectNodeUponCreation = True
     self.inputSelector.addEnabled = False
     self.inputSelector.removeEnabled = False


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.
