### PR TITLE
BUG: Remove BUILD_TESTING logic

### DIFF
--- a/ApplyMatrix/CMakeLists.txt
+++ b/ApplyMatrix/CMakeLists.txt
@@ -15,6 +15,6 @@ SEMMacroBuildCLI(
   EXECUTABLE_ONLY
   )
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/Downsize/CMakeLists.txt
+++ b/Downsize/CMakeLists.txt
@@ -15,7 +15,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
-
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/Growing/CMakeLists.txt
+++ b/Growing/CMakeLists.txt
@@ -16,7 +16,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
-
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/LabelAddition/CMakeLists.txt
+++ b/LabelAddition/CMakeLists.txt
@@ -16,6 +16,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/LabelExtraction/CMakeLists.txt
+++ b/LabelExtraction/CMakeLists.txt
@@ -14,6 +14,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/MaskCreation/CMakeLists.txt
+++ b/MaskCreation/CMakeLists.txt
@@ -16,6 +16,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()

--- a/NonGrowing/CMakeLists.txt
+++ b/NonGrowing/CMakeLists.txt
@@ -16,6 +16,6 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
-if(NOT BUILD_TESTING)
-  add_subdirectory(Testing)
-endif()
+# if(BUILD_TESTING)
+#   add_subdirectory(Testing)
+# endif()


### PR DESCRIPTION
There is not Testing package sub directory to add.
Also the logic was switched.

```
if(NOT BUILD_TESTING)
  add_subdirectory(Testing)
endif()
```

Removed the block.