### PR TITLE
Fix issues during ROI registration

### DIFF
--- a/SurfaceRegistration/SurfaceRegistration.py
+++ b/SurfaceRegistration/SurfaceRegistration.py
@@ -413,12 +413,7 @@ class SurfaceRegistrationWidget(ScriptedLoadableModuleWidget):
         if self.outputModelSelector.currentNode() and self.inputMovingModelSelector.currentNode():
             output = self.outputModelSelector.currentNode()
             input = self.inputMovingModelSelector.currentNode()
-
-            verts = input.GetPolyData().GetVerts()
-
-            print(f'{verts} {type(verts)}')
-
-            # self.logic.applyTransforms(output, input)
+            self.logic.applyTransforms(output, input)
 
     # Call on Fixed Model changes
     def onFixedModelChanged(self):

--- a/SurfaceRegistration/SurfaceRegistration.py
+++ b/SurfaceRegistration/SurfaceRegistration.py
@@ -1179,31 +1179,6 @@ class SurfaceRegistrationLogic():
             if disp:
                 disp.VisibilityOn()
 
-
-    def defineNeighbor(self, connectedVerticesList, inputModelNodePolyData, indexClosestPoint, distance):
-        self.GetConnectedVertices(connectedVerticesList, inputModelNodePolyData, indexClosestPoint)
-        if distance > 1:
-            for dist in range(1, int(distance)):
-                for i in range(0, connectedVerticesList.GetNumberOfIds()):
-                    self.GetConnectedVertices(connectedVerticesList, inputModelNodePolyData,
-                                              connectedVerticesList.GetId(i))
-        return connectedVerticesList
-
-    def GetConnectedVertices(self, connectedVerticesIDList, polyData, pointID):
-        # Return IDs of all the vertices that compose the first neighbor.
-        cellList = vtk.vtkIdList()
-        connectedVerticesIDList.InsertUniqueId(pointID)
-        # Get cells that vertex 'pointID' belongs to
-        polyData.GetPointCells(pointID, cellList)
-        numberOfIds = cellList.GetNumberOfIds()
-        for i in range(0, numberOfIds):
-            # Get points which compose all cells
-            pointIdList = vtk.vtkIdList()
-            polyData.GetCellPoints(cellList.GetId(i), pointIdList)
-            for j in range(0, pointIdList.GetNumberOfIds()):
-                connectedVerticesIDList.InsertUniqueId(pointIdList.GetId(j))
-        return connectedVerticesIDList
-
     def addArrayFromIdList(self, connectedIdList, inputModelNode, arrayName):
         if not inputModelNode:
             return
@@ -1568,90 +1543,6 @@ class SurfaceRegistrationTest(ScriptedLoadableModuleTest):
                 return False
             else:
                 print("test ",i ," ReplaceLandmark: succeed")
-        return True
-
-    def testDefineNeighborsFunction(self):
-        logic = SurfaceRegistrationLogic(slicer.modules.SurfaceRegistrationWidget)
-        sphereModel = self.defineSphere()
-        polyData = sphereModel.GetPolyData()
-        closestPointIndexList = [9, 35, 1]
-        connectedVerticesReferenceList = list()
-        connectedVerticesReferenceList.append([9, 2, 3, 8, 10, 15, 16])
-        connectedVerticesReferenceList.append(
-            [35, 28, 29, 34, 36, 41, 42, 21, 22, 27, 23, 30, 33, 40, 37, 43, 47, 48, 49])
-        connectedVerticesReferenceList.append(
-            [1, 7, 13, 19, 25, 31, 37, 43, 49, 6, 48, 12, 18, 24, 30, 36, 42, 5, 47, 41, 11, 17, 23, 29, 35])
-        connectedVerticesTestedList = list()
-
-        for i in range(0, 3):
-            inter = vtk.vtkIdList()
-            logic.defineNeighbor(inter,
-                                 polyData,
-                                 closestPointIndexList[i],
-                                 i + 1)
-            connectedVerticesTestedList.append(inter)
-            list1 = list()
-            for j in range(0, connectedVerticesTestedList[i].GetNumberOfIds()):
-                list1.append(int(connectedVerticesTestedList[i].GetId(j)))
-            connectedVerticesTestedList[i] = list1
-            if connectedVerticesTestedList[i] != connectedVerticesReferenceList[i]:
-                print("test ",i ," AddArrayFromIdList: failed")
-                return False
-            else:
-                print("test ",i ," AddArrayFromIdList: succeed")
-        return True
-
-    def testAddArrayFromIdListFunction(self):
-        logic = SurfaceRegistrationLogic(slicer.modules.SurfaceRegistrationWidget)
-        sphereModel = self.defineSphere()
-        polyData = sphereModel.GetPolyData()
-        closestPointIndexList = [9, 35, 1]
-        for i in range(0, 3):
-            inter = vtk.vtkIdList()
-            logic.defineNeighbor(inter, polyData, closestPointIndexList[i], i + 1)
-            logic.addArrayFromIdList(inter,
-                                     sphereModel,
-                                     'Test_' + str(i + 1))
-            if polyData.GetPointData().HasArray('Test_' + str(i + 1)) != 1:
-                print("test ",i ," AddArrayFromIdList: failed")
-                return False
-            else:
-                print("test ",i ," AddArrayFromIdList: succeed")
-        return True
-
-    def testGetROIPolydata(self):
-        logic = SurfaceRegistrationLogic(slicer.modules.SurfaceRegistrationWidget)
-        sphereModel = self.defineSphere()
-        harden = slicer.mrmlScene.AddNode(sphereModel)
-        logic.updateDictModel(sphereModel)
-        closestPointIndexList = [9, 35, 1]
-        XPosition = list()
-        YPosition = list()
-        ZPosition = list()
-        XPosition.append([0.0, 43.38837432861328, 78.18315124511719, 97.49279022216797, 30.680213928222656, 55.28383255004883, 68.93781280517578, 68.93781280517578, 2.6567715668640796e-15, 4.7873370442571075e-15, 5.969711605878806e-15, 5.969711605878806e-15, -55.28383255004883, -68.93781280517578, -68.93781280517578, 30.680213928222656, 55.28383255004883])
-        YPosition.append([0.0, 0.0, 0.0, 0.0, 30.680213928222656, 55.28383255004883, 68.93781280517578, 68.93781280517578, 43.38837432861328, 78.18315124511719, 97.49279022216797, 97.49279022216797, 55.28383255004883, 68.93781280517578, 68.93781280517578, -30.680213928222656, -55.28383255004883])
-        ZPosition.append([100.0, 90.09688568115234, 62.34897994995117, 22.252094268798828, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, 62.34897994995117, 22.252094268798828, -22.252094268798828, 90.09688568115234, 62.34897994995117])
-        XPosition.append([0.0, 97.49279022216797, 78.18315124511719, 43.38837432861328, 2.6567715668640796e-15, 4.7873370442571075e-15, 5.969711605878806e-15, 5.969711605878806e-15, -30.680213928222656, -55.28383255004883, -68.93781280517578, -68.93781280517578, -55.28383255004883, -43.38837432861328, -78.18315124511719, -97.49279022216797, -97.49279022216797, -78.18315124511719, -43.38837432861328, -30.680213928222656, -55.28383255004883, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656, -1.4362011132771323e-14, -1.7909134394119945e-14, -1.7909134394119945e-14, -1.4362011132771323e-14, -7.970314912350476e-15, 68.93781280517578, 68.93781280517578, 55.28383255004883, 30.680213928222656])
-        YPosition.append([0.0, 0.0, 0.0, 0.0, 43.38837432861328, 78.18315124511719, 97.49279022216797, 97.49279022216797, 30.680213928222656, 55.28383255004883, 68.93781280517578, 68.93781280517578, 55.28383255004883, 5.313543133728159e-15, 9.574674088514215e-15, 1.1939423211757613e-14, 1.1939423211757613e-14, 9.574674088514215e-15, 5.313543133728159e-15, -30.680213928222656, -55.28383255004883, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656, -78.18315124511719, -97.49279022216797, -97.49279022216797, -78.18315124511719, -43.38837432861328, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656])
-        ZPosition.append([-100.0, -22.252094268798828, -62.34897994995117, -90.09688568115234, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, -62.34897994995117, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 62.34897994995117, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234])
-        XPosition.append([0.0, 97.49279022216797, 97.49279022216797, 78.18315124511719, 43.38837432861328, 68.93781280517578, 68.93781280517578, 55.28383255004883, 30.680213928222656, 5.969711605878806e-15, 5.969711605878806e-15, 4.7873370442571075e-15, 2.6567715668640796e-15, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656, -97.49279022216797, -97.49279022216797, -78.18315124511719, -43.38837432861328, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656, -1.7909134394119945e-14, -1.7909134394119945e-14, -1.4362011132771323e-14, -7.970314912350476e-15, 68.93781280517578, 68.93781280517578, 55.28383255004883, 30.680213928222656])
-        YPosition.append([0.0, 0.0, 0.0, 0.0, 0.0, 68.93781280517578, 68.93781280517578, 55.28383255004883, 30.680213928222656, 97.49279022216797, 97.49279022216797, 78.18315124511719, 43.38837432861328, 68.93781280517578, 68.93781280517578, 55.28383255004883, 30.680213928222656, 1.1939423211757613e-14, 1.1939423211757613e-14, 9.574674088514215e-15, 5.313543133728159e-15, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656, -97.49279022216797, -97.49279022216797, -78.18315124511719, -43.38837432861328, -68.93781280517578, -68.93781280517578, -55.28383255004883, -30.680213928222656])
-        ZPosition.append([-100.0, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234, 22.252094268798828, -22.252094268798828, -62.34897994995117, -90.09688568115234])
-        for i in range(0, 3):
-            inter = vtk.vtkIdList()
-            logic.defineNeighbor(inter,
-                                 harden.GetPolyData(),
-                                 closestPointIndexList[i],
-                                 i + 1)
-            logic.dictionaryInput[sphereModel.GetID()].ROIPointListID = inter
-            ROIPolydata = logic.getROIPolydata(sphereModel)
-            for j in range (0,ROIPolydata.GetNumberOfPoints()):
-                if ROIPolydata.GetPoint(j)[0] != XPosition[i][j] \
-                        or ROIPolydata.GetPoint(j)[1] != YPosition[i][j] \
-                        or ROIPolydata.GetPoint(j)[2] != ZPosition[i][j]:
-                    print("test ",i ," GetROIPolydata: failed")
-                    return False
-            print("test ",i ," GetROIPolydata: succeed")
         return True
 
     def testRunFiducialRegistration(self):

--- a/SurfaceRegistration/SurfaceRegistration.py
+++ b/SurfaceRegistration/SurfaceRegistration.py
@@ -64,14 +64,14 @@ class SurfaceRegistrationWidget(ScriptedLoadableModuleWidget):
         self.layout = self.parent.layout()
         self.widget = widget
         self.layout.addWidget(widget)
-        
+
         self.SceneCollapsibleButton = self.logic.get("SceneCollapsibleButton") # this atribute is usefull for Longitudinal quantification extension
         treeView = self.logic.get("treeView")
         treeView.setMRMLScene(slicer.app.mrmlScene())
         treeView.sceneModel().setHorizontalHeaderLabels(["Models"])
         treeView.sortFilterProxyModel().nodeTypes = ['vtkMRMLModelNode','vtkMRMLMarkupsFiducialNode']
         treeView.header().setVisible(False)
-        
+
         self.registrationCollapsibleButton = self.logic.get("registrationCollapsibleButton")
         self.fiducialRegistration = self.logic.get("fiducialRegistration")
         self.surfaceRegistration = self.logic.get("surfaceRegistration")
@@ -1036,7 +1036,7 @@ class SurfaceRegistrationLogic():
                 landmark2ID = landmarkDescription[midPointID]["midPoint"]["Point2"]
                 coord = self.calculateMidPointCoord(fidList, landmark1ID, landmark2ID)
                 index = fidList.GetNthControlPointIndexByID(midPointID)
-                fidList.SetNthFiducialPositionFromArray(index, coord)
+                fidList.SetNthControlPointPositionFromArray(index, coord, fidList.PositionPreview)
                 if landmarkDescription[midPointID]["projection"]["isProjected"]:
                     hardenModel = slicer.app.mrmlScene().GetNodeByID(fidList.GetAttribute("hardenModelID"))
                     landmarkDescription[midPointID]["projection"]["closestPointIndex"] = \
@@ -1125,7 +1125,7 @@ class SurfaceRegistrationLogic():
         landmarkCoord = [-1, -1, -1]
         fidNode.GetNthFiducialPosition(landmarkID, landmarkCoord)
         inputModelPolyData.GetPoints().GetPoint(indexClosestPoint, landmarkCoord)
-        fidNode.SetNthFiducialPositionFromArray(landmarkID,landmarkCoord)
+        fidNode.SetNthControlPointPositionFromArray(landmarkID, landmarkCoord, fidNode.PositionPreview)
 
     def projectOnSurface(self, modelOnProject, fidNode, selectedFidReflID):
         if selectedFidReflID:


### PR DESCRIPTION
This PR addresses the issues mentioned in issue #29. 

The landmark placement issue is caused by the markup placement mode defining the markup's position on mouse movement; when the position is undefined or tentative the markup is correctly handled when the cursor leaves the active 3D view.

The issues regarding ROI radius seem to be due to the depth-first mesh traversal around each markup taking too long for "large" radius (about 20). I've improved the complexity of that algorithm. I've been unable to duplicate the program exiting as described in the issue, but I believe this would be due to memory constraints or similar when the mesh traversal hangs. If that's correct, then this change should address that as well. 