### PR TITLE
COMP: Fix missing VTK libraries

### DIFF
--- a/ApplyMatrix/CMakeLists.txt
+++ b/ApplyMatrix/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME ApplyMatrix)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------

--- a/Growing/CMakeLists.txt
+++ b/Growing/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME Growing)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------

--- a/LabelAddition/CMakeLists.txt
+++ b/LabelAddition/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME LabelAddition)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------

--- a/LabelExtraction/CMakeLists.txt
+++ b/LabelExtraction/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME LabelExtraction)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------

--- a/MaskCreation/CMakeLists.txt
+++ b/MaskCreation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME MaskCreation)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------

--- a/NonGrowing/CMakeLists.txt
+++ b/NonGrowing/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MODULE_NAME NonGrowing)
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Modules depend on VTK but do not use `${VTK_LIBRARIES}`

Resolves #34 