### PR TITLE
Fix deprecations

### DIFF
--- a/SurfaceRegistration/SurfaceRegistration.py
+++ b/SurfaceRegistration/SurfaceRegistration.py
@@ -740,7 +740,7 @@ class SurfaceRegistrationLogic():
         icp.Update()
         outputMatrix = vtk.vtkMatrix4x4()
         icp.GetMatrix(outputMatrix)
-        outputTrans.SetAndObserveMatrixTransformToParent(outputMatrix)
+        outputTrans.SetMatrixTransformToParent(outputMatrix)
         return
 
     def createIntermediateHardenModel(self, model):

--- a/SurfaceRegistration/SurfaceRegistration.py
+++ b/SurfaceRegistration/SurfaceRegistration.py
@@ -412,6 +412,7 @@ class SurfaceRegistrationWidget(ScriptedLoadableModuleWidget):
         print("---------undo-------------")
         movingModel = self.inputMovingModelSelector.currentNode()
         self.logic.undoDisplay(movingModel)
+        self.outputTransformSelector.setCurrentNodeID(movingModel.GetAttribute("lastTransformID"))
         self.undoButton.enabled = False
         self.fixedModel.setChecked(True)
         self.onFixedModelRadio()


### PR DESCRIPTION
_Partially_ addresses #37. The deprecation warning is resolved. I also updated the undo functionality to reset the output transform; it's a bit easier to iterate on different settings for registration.

@bpaniagua I have found with certain settings it's possible to register the problematic case, however the surface registration cannot correctly rotate or reflect the moving model even in affine mode; fixing _this_ bug is much more difficult and I haven't had success identifying the root cause.

One can manually rotate and reflect the moving model _before_ registration which improves the results.

Note that reflecting the model inverts its normals; so further work would need done to correct those.

Without preprocessing:

![Without preprocessing](https://user-images.githubusercontent.com/10702931/222219841-91234abf-e920-4ee3-8f36-07ee3a4fa9bb.png)

Pre-reflected:

![Pre-reflected](https://user-images.githubusercontent.com/10702931/222219835-03312fd7-8479-440d-a534-d8ae7651435b.png)
