### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(CMFreg)
 
 #-----------------------------------------------------------------------------
 set(EXTENSION_NAME "CMFreg")
-set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/4.4/Extensions/CMFreg")
+set(EXTENSION_HOMEPAGE "https://www.slicer.org/slicerWiki/index.php/Documentation/4.4/Extensions/CMFreg")
 set(EXTENSION_CATEGORY "Registration")
 set(EXTENSION_CONTRIBUTORS "Vinicius Boen (Univ of Michigan), Manson Winsauer (UNC), Jean-Baptiste Vimort (Univ of Michigan)")
 set(EXTENSION_DESCRIPTION "Tools package for the cranio-maxillofacial registration")
-set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/b/bc/BaselineFollowupSCANRegisteredCMFreg2.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/1/15/BaselineFollowupSCANCMFreg.png http://www.slicer.org/slicerWiki/images/0/0b/GrowingInterface.png http://www.slicer.org/slicerWiki/images/4/4a/InputSegToExtractionCMFreg.png http://www.slicer.org/slicerWiki/images/4/46/BaselineSegmentationMaskCMFreg.png")
+set(EXTENSION_ICONURL "https://www.slicer.org/slicerWiki/images/b/bc/BaselineFollowupSCANRegisteredCMFreg2.png")
+set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/1/15/BaselineFollowupSCANCMFreg.png https://www.slicer.org/slicerWiki/images/0/0b/GrowingInterface.png https://www.slicer.org/slicerWiki/images/4/4a/InputSegToExtractionCMFreg.png https://www.slicer.org/slicerWiki/images/4/46/BaselineSegmentationMaskCMFreg.png")
 
 #-----------------------------------------------------------------------------
 find_package(Slicer REQUIRED)


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.